### PR TITLE
cast the environment variable to an integer

### DIFF
--- a/bin/sixpack-web
+++ b/bin/sixpack-web
@@ -7,7 +7,7 @@ from sixpack.web import app
 
 sys.path.append("..")
 
-port = os.environ.get('SIXPACK_WEB_PORT', 5001)
+port = int(os.environ.get('SIXPACK_WEB_PORT', 5001))
 debug = 'SIXPACK_DEBUG' in os.environ
 
 app.run(host='0.0.0.0', port=port, debug=debug)


### PR DESCRIPTION
when attempting to use the environment variable `SIXPACK_WEB_PORT` to alter the port number that the web uses I get the following error

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 859, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 732, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 471, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 335, in getMessage
    msg = msg % self.args
TypeError: %d format: a number is required, not str
Logged from file _internal.py, line 87
```

but the environment variable `SIXPACK_PORT` for setting the API port worked just fine.
after inspecting both `sixpack` and `sixpack-web` executables I noticed that `sixpack-web` did not cast it's environment variable to an integer before using it

correcting this fixed my error